### PR TITLE
Add: ability to use newer version of ruby

### DIFF
--- a/fastlane-plugin-translation.gemspec
+++ b/fastlane-plugin-translation.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'google-api-client', '0.9.20'
   spec.add_dependency 'google_drive', '2.1.1'
-  spec.add_dependency 'nokogiri', '1.5.3'
+  spec.add_dependency 'nokogiri', '>=1.5.3'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'

--- a/lib/fastlane/plugin/translation/version.rb
+++ b/lib/fastlane/plugin/translation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Translation
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end


### PR DESCRIPTION
In 2.3.* some stuff was renamed: https://github.com/sparklemotion/nokogiri/issues/1290