### PR TITLE
Conformity to .strings format

### DIFF
--- a/lib/fastlane/plugin/translation/actions/translation_action.rb
+++ b/lib/fastlane/plugin/translation/actions/translation_action.rb
@@ -41,7 +41,7 @@ module Fastlane
               key_row = row[key]
               value_row = row[index].gsub("\"", "\\\"")
               value_row = value_row.gsub("\n", "\\n")
-              file.write("#{key_row} = \"#{value_row}\";\n")
+              file.write("\"#{key_row}\" = \"#{value_row}\";\n")
             end
           end
           file.close


### PR DESCRIPTION
This pull request updates the csv-to-.strings converter to conform to the `.strings` format. 

The `.strings` output file from the current version of this plugin does not have `""` around the keys as seen in the examples from the official Apple documentation:
https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html